### PR TITLE
WORKDIR should be without quotes

### DIFF
--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -20,7 +20,7 @@ RUN chmod +x /drupal-setup.sh
 
 # Start
 
-WORKDIR "/var/www/html"
+WORKDIR /var/www/html
 VOLUME "/var/www/html"
 EXPOSE 22 80 3306
 CMD ["supervisord", "-n"]


### PR DESCRIPTION
WORKDIR should be without quotes, otherwise you end up on the path `/"/var/www/html"` (including the quotes), which looks very strange if you try to open up a bash shell afterwards (e.g. via `sudo docker exec -it <containerIdOrName> bash`). I also expect that later commands would not work as expected... ;-)
